### PR TITLE
Add frequency to recurrence

### DIFF
--- a/src/logic/schedule.ts
+++ b/src/logic/schedule.ts
@@ -70,6 +70,7 @@ export class Schedule {
 				start: section.start,
 				end: section.end,
 				recurrence: {
+					frequency: "DAILY",
 					weekdays: weekdays,
 					end: section.lastDate,
 				},


### PR DESCRIPTION
Adds a frequency to the recurrence property of each calendar event. This fixes importing issues in services other than Apple Calendar.

This issue fixes #1